### PR TITLE
Django Updated 2.0.6

### DIFF
--- a/apps/apps.py
+++ b/apps/apps.py
@@ -1,8 +1,0 @@
-# apps/base/apps.py
-from django.apps import AppConfig
-
-
-class BaseAppConfig(AppConfig):
-    name = 'apps.base'
-
-# 

--- a/apps/apps.py
+++ b/apps/apps.py
@@ -1,0 +1,8 @@
+# apps/base/apps.py
+from django.apps import AppConfig
+
+
+class BaseAppConfig(AppConfig):
+    name = 'apps.base'
+
+# 

--- a/apps/base/urls.py
+++ b/apps/base/urls.py
@@ -1,10 +1,10 @@
-"""urlconf for the base application"""
+"""urlconf for the {{ project_name }} application"""
 
-from django.conf.urls import url
+from django.urls import path
 
 from .views import home
 
 
 urlpatterns = [
-    url(r'^$', home, name='home'),
+    path('', home, name='home'),
 ]

--- a/apps/base/urls.py
+++ b/apps/base/urls.py
@@ -1,10 +1,10 @@
 """urlconf for the base application"""
 
-from django.conf.urls import url
+from django.urls import path
 
 from .views import home
 
 
 urlpatterns = [
-    url(r'^$', home, name='home'),
+    path('', home, name='home'),
 ]

--- a/apps/base/urls.py
+++ b/apps/base/urls.py
@@ -1,10 +1,10 @@
 """urlconf for the base application"""
 
-from django.urls import path
+from django.conf.urls import url
 
 from .views import home
 
 
 urlpatterns = [
-    path('', home, name='home'),
+    url(r'^$', home, name='home'),
 ]

--- a/pipsetup.py
+++ b/pipsetup.py
@@ -1,0 +1,36 @@
+import sys
+import subprocess
+import os
+
+# default dependencies, 
+def printPackage(package):
+    print('----------------------------------------------------------------##')
+    print("Installed Package: {}".format(package))
+    print('----------------------------------------------------------------##')
+
+
+def install(package, arg):
+
+    if arg:
+        subprocess.call([sys.executable, '-m', 'pip', 'install', package, arg])
+    else:
+        subprocess.call([sys.executable, '-m', 'pip', 'install', package])
+
+    printPackage(package)
+
+
+if __name__ == '__main__':
+    packages = {
+        'rcssmin ': '--install-option="--without-c-extensions"',
+        'rjsmin ': '--install-option="--without-c-extensions"',
+        # rcssmin and rjsmin have to be installed this way.
+        'django~=2.0.0': '',
+        'django-admin': '',
+        'django-compressor': '--upgrade',
+        'django[argon2]': '',
+        'django-debug-toolbar': ''
+    }
+
+    for k, v in packages.items():
+        install(k, v)
+

--- a/project_name/settings/base.py
+++ b/project_name/settings/base.py
@@ -17,8 +17,7 @@ path.append(BASE_DIR)
 # This directory contains the django project, apps, libs, etc...
 PROJECT_ROOT = os.path.dirname(BASE_DIR)
 
-# Add apps and libs to the PROJECT_ROOT
-path.append(os.path.join(PROJECT_ROOT, "apps"))
+# Add libs to the PROJECT_ROOT
 path.append(os.path.join(PROJECT_ROOT, "libs"))
 
 
@@ -48,7 +47,7 @@ INSTALLED_APPS = [
     'compressor',
 
     # Local apps
-    'apps.base',
+    'apps.base.apps.BaseAppConfig',
 ]
 
 # https://docs.djangoproject.com/en/2.0/topics/auth/passwords/#using-argon2-with-django

--- a/project_name/settings/base.py
+++ b/project_name/settings/base.py
@@ -10,7 +10,7 @@ import os
 
 # PATHS
 # Path containing the django project
-BASE_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 path.append(BASE_DIR)
 
 # Path of the top level directory.
@@ -48,7 +48,7 @@ INSTALLED_APPS = [
     'compressor',
 
     # Local apps
-    'apps.base',
+    'base',
 ]
 
 # https://docs.djangoproject.com/en/2.0/topics/auth/passwords/#using-argon2-with-django

--- a/project_name/settings/base.py
+++ b/project_name/settings/base.py
@@ -10,7 +10,7 @@ import os
 
 # PATHS
 # Path containing the django project
-BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+BASE_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 path.append(BASE_DIR)
 
 # Path of the top level directory.
@@ -48,7 +48,7 @@ INSTALLED_APPS = [
     'compressor',
 
     # Local apps
-    'base',
+    'apps.base',
 ]
 
 # https://docs.djangoproject.com/en/2.0/topics/auth/passwords/#using-argon2-with-django

--- a/project_name/settings/base.py
+++ b/project_name/settings/base.py
@@ -17,7 +17,8 @@ path.append(BASE_DIR)
 # This directory contains the django project, apps, libs, etc...
 PROJECT_ROOT = os.path.dirname(BASE_DIR)
 
-# Add libs to the PROJECT_ROOT
+# Add libs and apps to the PROJECT_ROOT
+path.append(os.path.join(PROJECT_ROOT, "apps"))
 path.append(os.path.join(PROJECT_ROOT, "libs"))
 
 
@@ -47,7 +48,7 @@ INSTALLED_APPS = [
     'compressor',
 
     # Local apps
-    'apps.base.apps.BaseAppConfig',
+    'apps.base',
 ]
 
 # https://docs.djangoproject.com/en/2.0/topics/auth/passwords/#using-argon2-with-django

--- a/project_name/urls.py
+++ b/project_name/urls.py
@@ -1,7 +1,7 @@
 """ Default urlconf for {{ project_name }} """
 
 from django.conf import settings
-from django.conf.urls import include, url
+from django.conf.urls import include
 from django.conf.urls.static import static
 from django.contrib import admin
 from django.contrib.sitemaps.views import index, sitemap
@@ -16,18 +16,18 @@ sitemaps = {
 }
 
 urlpatterns = [
-    url(r'', include('base.urls')),
+    path('', include('apps.base.urls')),
 
     # Admin
-    url(r'^admin/', admin.site.urls),
-    url(r'^admin/doc/', include('django.contrib.admindocs.urls')),
+    path('admin/', admin.site.urls),
+    path('admin/doc/', include('django.contrib.admindocs.urls')),
 
     # Sitemap
-    url(r'^sitemap\.xml$', index, {'sitemaps': sitemaps}),
-    url(r'^sitemap-(?P<section>.+)\.xml$', sitemap, {'sitemaps': sitemaps}),
+    path(r'sitemap\.xml', index, {'sitemaps': sitemaps}),
+    path(r'sitemap-<section:section>\.xml', sitemap, {'sitemaps': sitemaps}),
 
     # robots.txt
-    url(r'^robots\.txt$',
+    path(r'robots\.txt',
         TemplateView.as_view(
             template_name='robots.txt',
             content_type='text/plain')
@@ -37,7 +37,7 @@ urlpatterns = [
 if settings.DEBUG:
     # Add debug-toolbar
     import debug_toolbar  # noqa
-    urlpatterns.append(url(r'^__debug__/', include(debug_toolbar.urls)))
+    urlpatterns.append(path('^__debug__/', include(debug_toolbar.urls)))
 
     # Serve media files through Django.
     urlpatterns += static(settings.STATIC_URL,
@@ -47,13 +47,7 @@ if settings.DEBUG:
 
     # Show error pages during development
     urlpatterns += [
-<<<<<<< HEAD
         path('403/', permission_denied),
         path('404/', page_not_found),
         path('500/', server_error)
-=======
-        url(r'^403/$', permission_denied),
-        url(r'^404/$', page_not_found),
-        url(r'^500/$', server_error)
->>>>>>> parent of a6a546a... Changes to BASE_DIR to point to the right directory and django.urls 'url' to 'path'.
     ]

--- a/project_name/urls.py
+++ b/project_name/urls.py
@@ -2,6 +2,7 @@
 
 from django.conf import settings
 from django.conf.urls import include
+from django.urls import path
 from django.conf.urls.static import static
 from django.contrib import admin
 from django.contrib.sitemaps.views import index, sitemap

--- a/project_name/urls.py
+++ b/project_name/urls.py
@@ -48,7 +48,7 @@ if settings.DEBUG:
 
     # Show error pages during development
     urlpatterns += [
-        path(r'403/', permission_denied),
-        path(r'404/', page_not_found),
-        path(r'500/', server_error)
+        path('403/', permission_denied),
+        path('404/', page_not_found),
+        path('500/', server_error)
     ]

--- a/project_name/urls.py
+++ b/project_name/urls.py
@@ -2,6 +2,7 @@
 
 from django.conf import settings
 from django.conf.urls import include, url
+from django.urls import path
 from django.conf.urls.static import static
 from django.contrib import admin
 from django.contrib.sitemaps.views import index, sitemap
@@ -16,28 +17,28 @@ sitemaps = {
 }
 
 urlpatterns = [
-    url(r'', include('base.urls')),
+    path('', include('apps.base.urls')),
 
     # Admin
-    url(r'^admin/', admin.site.urls),
-    url(r'^admin/doc/', include('django.contrib.admindocs.urls')),
+    path('admin/', admin.site.urls),
+    path('admin/doc/', include('django.contrib.admindocs.urls')),
 
     # Sitemap
-    url(r'^sitemap\.xml$', index, {'sitemaps': sitemaps}),
-    url(r'^sitemap-(?P<section>.+)\.xml$', sitemap, {'sitemaps': sitemaps}),
+    path(r'sitemap\.xml', index, {'sitemaps': sitemaps}),
+    path(r'^sitemap-<section:section>\.xml', sitemap, {'sitemaps': sitemaps}),
 
     # robots.txt
-    url(r'^robots\.txt$',
-        TemplateView.as_view(
-            template_name='robots.txt',
-            content_type='text/plain')
-        ),
+    path(r'robots\.txt',
+         TemplateView.as_view(
+             template_name='robots.txt',
+             content_type='text/plain')
+         ),
 ]
 
 if settings.DEBUG:
     # Add debug-toolbar
     import debug_toolbar  # noqa
-    urlpatterns.append(url(r'^__debug__/', include(debug_toolbar.urls)))
+    urlpatterns.append(path('__debug__/', include(debug_toolbar.urls)))
 
     # Serve media files through Django.
     urlpatterns += static(settings.STATIC_URL,
@@ -47,7 +48,7 @@ if settings.DEBUG:
 
     # Show error pages during development
     urlpatterns += [
-        url(r'^403/$', permission_denied),
-        url(r'^404/$', page_not_found),
-        url(r'^500/$', server_error)
+        path(r'403/', permission_denied),
+        path(r'404/', page_not_found),
+        path(r'500/', server_error)
     ]

--- a/project_name/urls.py
+++ b/project_name/urls.py
@@ -2,7 +2,6 @@
 
 from django.conf import settings
 from django.conf.urls import include, url
-from django.urls import path
 from django.conf.urls.static import static
 from django.contrib import admin
 from django.contrib.sitemaps.views import index, sitemap
@@ -17,28 +16,28 @@ sitemaps = {
 }
 
 urlpatterns = [
-    path('', include('apps.base.urls')),
+    url(r'', include('base.urls')),
 
     # Admin
-    path('admin/', admin.site.urls),
-    path('admin/doc/', include('django.contrib.admindocs.urls')),
+    url(r'^admin/', admin.site.urls),
+    url(r'^admin/doc/', include('django.contrib.admindocs.urls')),
 
     # Sitemap
-    path(r'sitemap\.xml', index, {'sitemaps': sitemaps}),
-    path(r'^sitemap-<section:section>\.xml', sitemap, {'sitemaps': sitemaps}),
+    url(r'^sitemap\.xml$', index, {'sitemaps': sitemaps}),
+    url(r'^sitemap-(?P<section>.+)\.xml$', sitemap, {'sitemaps': sitemaps}),
 
     # robots.txt
-    path(r'robots\.txt',
-         TemplateView.as_view(
-             template_name='robots.txt',
-             content_type='text/plain')
-         ),
+    url(r'^robots\.txt$',
+        TemplateView.as_view(
+            template_name='robots.txt',
+            content_type='text/plain')
+        ),
 ]
 
 if settings.DEBUG:
     # Add debug-toolbar
     import debug_toolbar  # noqa
-    urlpatterns.append(path('__debug__/', include(debug_toolbar.urls)))
+    urlpatterns.append(url(r'^__debug__/', include(debug_toolbar.urls)))
 
     # Serve media files through Django.
     urlpatterns += static(settings.STATIC_URL,
@@ -48,7 +47,13 @@ if settings.DEBUG:
 
     # Show error pages during development
     urlpatterns += [
+<<<<<<< HEAD
         path('403/', permission_denied),
         path('404/', page_not_found),
         path('500/', server_error)
+=======
+        url(r'^403/$', permission_denied),
+        url(r'^404/$', page_not_found),
+        url(r'^500/$', server_error)
+>>>>>>> parent of a6a546a... Changes to BASE_DIR to point to the right directory and django.urls 'url' to 'path'.
     ]

--- a/readme.md
+++ b/readme.md
@@ -15,11 +15,22 @@ Make sure you have [pipenv installed](https://docs.pipenv.org/install.html). The
 
     pip install django==2.0
 
+
 To create a new Django project (make sure to change `project_name`)
 
     django-admin.py startproject --template=https://github.com/fasouto/django-starter-template/archive/master.zip --extension=py,md,html,txt project_name
 
 cd to your project and install the development dependences
+
+- Linux - cd to directory and:
+
+      pipsetup.py
+
+- Windows 
+ 
+      python pipsetup.py
+
+or 
 
     pipenv install --dev
 


### PR DESCRIPTION
Some fixes, 
- Users will be able to write standalone scripts (and other improvements) and changed from regex urls to new path. 
-- Specifics: 
---- Changes to BASE_DIR and sysPATH 
----  Changed from django.urls > url  to path  ( as regex url is going to get depreciated at some point and if used it should be re_path 

'url()¶
url(regex, view, kwargs=None, name=None)[source]¶
This function is an alias to django.urls.re_path(). It’s likely to be deprecated in a future release.'

BASE_DIR was pointing to the wrong directory. 